### PR TITLE
Add a APP_SMITHY_CLASSPATH, tweak codegen

### DIFF
--- a/modules/api/src/main/resources/META-INF/smithy/SmithyCodeGenerationService.smithy
+++ b/modules/api/src/main/resources/META-INF/smithy/SmithyCodeGenerationService.smithy
@@ -52,6 +52,7 @@ operation Smithy4sConvert {
         @required
         generated: Smithy4sGeneratedContent
     }
+    errors: [InvalidSmithyContent]
 }
 
 string Path

--- a/modules/backend/src/main/scala/smithy4s/codegen/internals/CodegenTrick.scala
+++ b/modules/backend/src/main/scala/smithy4s/codegen/internals/CodegenTrick.scala
@@ -1,0 +1,15 @@
+package smithy4s.codegen.internals
+
+import smithy4s_codegen.generation.CodegenResult
+import software.amazon.smithy.model.Model
+
+object CodegenTrick {
+  def run(
+      model: Model,
+      allowedNS: Option[Set[String]],
+      excludedNS: Option[Set[String]]
+  ): List[(os.RelPath, CodegenResult)] =
+    CodegenImpl
+      .generate(model, allowedNS, excludedNS)
+      .map { case (p, r) => p -> CodegenResult(r.namespace, r.name, r.content) }
+}

--- a/modules/backend/src/main/scala/smithy4s_codegen/Main.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/Main.scala
@@ -1,24 +1,31 @@
 package smithy4s_codegen
 
 import cats.effect._
+import cats.effect.std.Env
+import cats.effect.syntax.resource._
 import cats.implicits._
 import com.comcast.ip4s._
 import org.http4s._
 import org.http4s.ember.server._
 import org.http4s.implicits._
 import smithy4s._
-import smithy4s_codegen.api._
 import smithy4s.http4s.SimpleRestJsonBuilder
-import smithy4s_codegen.smithy.Validate
+import smithy4s_codegen.api._
 import smithy4s_codegen.generation.Smithy4s
+import smithy4s_codegen.smithy.Validate
 
-object SmithyCodeGenerationServiceImpl extends SmithyCodeGenerationService[IO] {
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class SmithyCodeGenerationServiceImpl(generator: Smithy4s, validator: Validate)
+    extends SmithyCodeGenerationService[IO] {
   def healthCheck(): IO[HealthCheckOutput] = IO.pure {
     HealthCheckOutput("ok")
   }
 
   def smithy4sConvert(content: String): IO[Smithy4sConvertOutput] = {
-    Smithy4s
+    generator
       .generate(content)
       .map {
         _.map { case (path, content) =>
@@ -28,7 +35,7 @@ object SmithyCodeGenerationServiceImpl extends SmithyCodeGenerationService[IO] {
       .map(Smithy4sConvertOutput(_))
   }
   def smithyValidate(content: String): IO[Unit] = {
-    IO.delay(Validate.validateContent(content)).flatMap {
+    validator.validateContent(content).flatMap {
       case Right(value) => IO.unit
       case Left(value)  => IO.raiseError(InvalidSmithyContent(value.toList))
     }
@@ -37,21 +44,53 @@ object SmithyCodeGenerationServiceImpl extends SmithyCodeGenerationService[IO] {
 
 object Routes {
   import org.http4s.server.middleware.CORS
-  private val example: Resource[IO, HttpRoutes[IO]] =
-    SimpleRestJsonBuilder
-      .routes(SmithyCodeGenerationServiceImpl)
-      .resource
-      .map(CORS(_))
+  def exampleRoute(localJars: List[File]): Resource[IO, HttpRoutes[IO]] =
+    Resource
+      .eval(
+        (Validate(localJars), IO.pure(new Smithy4s(localJars))).tupled
+      )
+      .flatMap { case (validator, generator) =>
+        SimpleRestJsonBuilder
+          .routes(new SmithyCodeGenerationServiceImpl(generator, validator))
+          .resource
+          .map(CORS(_))
+      }
 
   private val docs: HttpRoutes[IO] =
     smithy4s.http4s.swagger.docs[IO](SmithyCodeGenerationService)
 
-  val all: Resource[IO, HttpRoutes[IO]] =
-    example.map(_ <+> docs <+> Frontend.routes)
+  def fullRoutes(routes: HttpRoutes[IO]): HttpRoutes[IO] =
+    routes <+> docs <+> Frontend.routes
 }
 
 object Main extends IOApp.Simple {
-  val run = Routes.all.flatMap { routes =>
+
+  val envSmithyClasspath: IO[List[File]] = Env[IO]
+    .get("APP_SMITHY_CLASSPATH")
+    .map(
+      _.map(_.trim().split(":").toList)
+        .getOrElse(List.empty)
+    )
+    .flatMap(files =>
+      files.traverse { fileLocation =>
+        val path = Paths.get(fileLocation)
+        IO.delay(Files.exists(path))
+          .ifM(
+            path.toFile.pure[IO],
+            IO.raiseError(
+              new IllegalArgumentException(
+                "APP_SMITHY_CLASSPATH contains bad values."
+              )
+            )
+          )
+
+      }
+    )
+
+  val server = for {
+    smithyClasspath <- envSmithyClasspath.toResource
+    routes <- Routes.exampleRoute(smithyClasspath).map(Routes.fullRoutes)
+  } yield {
     val thePort = port"9000"
     val theHost = host"0.0.0.0"
     EmberServerBuilder
@@ -59,8 +98,8 @@ object Main extends IOApp.Simple {
       .withPort(thePort)
       .withHost(theHost)
       .withHttpApp(routes.orNotFound)
-      .build <*
-      Resource.eval(IO.println(s"Server started on: $theHost:$thePort"))
-  }.useForever
+      .build
+  }
+  override val run = server.useForever
 
 }

--- a/modules/backend/src/main/scala/smithy4s_codegen/generation/Smithy4s.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/generation/Smithy4s.scala
@@ -1,73 +1,28 @@
 package smithy4s_codegen.generation
-
 import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.effect.Resource
 import cats.effect.syntax.all._
 import cats.syntax.all._
 import smithy4s.codegen._
+import smithy4s.codegen.internals.CodegenTrick
+import smithy4s_codegen.smithy.ModelLoader
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.validation.ValidationEvent
 
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import scala.jdk.CollectionConverters._
 
-final case class Smithy4sWorkspace(
-    input: os.Path,
-    output: os.Path,
-    specs: List[os.Path]
-)
+case class CodegenResult(namespace: String, name: String, content: String)
 
-final class Smithy4s(localJars: List[File]) {
+final class Smithy4s(modelLoader: ModelLoader) {
   def generate(
       content: String
-  ): IO[Vector[(Path, String)]] = {
-    val prepare = for {
-      workspace <- newWorkspace
-      _ <- IO.delay(os.makeDir(workspace.input)).toResource
-      smithyFilePath = workspace.input / "frontend.smithy"
-      _ <- IO
-        .delay(os.write(smithyFilePath, content))
-        .toResource
-    } yield workspace.copy(specs = workspace.specs :+ smithyFilePath)
-    prepare.use { workspace =>
-      val args = CodegenArgs(
-        workspace.specs,
-        workspace.output,
-        resourceOutput = workspace.output,
-        skip = Set(FileType.Resource, FileType.Openapi),
-        discoverModels = true,
-        allowedNS = None,
-        excludedNS = None,
-        dependencies = List.empty,
-        repositories = List.empty,
-        transformers = List.empty,
-        localJars = localJars.map(os.Path(_))
-      )
-      IO.delay(Codegen.processSpecs(args))
-        .flatMap(withContents(workspace.output))
-    }
+  ): Either[List[ValidationEvent], List[(os.RelPath, CodegenResult)]] = {
+    modelLoader
+      .load(content)
+      .map(model => CodegenTrick.run(model, None, None))
   }
-
-  private def newWorkspace: Resource[IO, Smithy4sWorkspace] =
-    fs2.io.file
-      .Files[IO]
-      .tempDirectory
-      .map { path =>
-        val osPath = os.Path(path.toNioPath)
-        Smithy4sWorkspace(
-          input = osPath / "input",
-          output = osPath / "output",
-          specs = List.empty
-        )
-      }
-
-  private def withContents(
-      output: os.Path
-  )(paths: Set[os.Path]): IO[Vector[(Path, String)]] =
-    paths.toVector.traverse { p =>
-      IO.delay(p.relativeTo(output).toNIO -> os.read(p))
-    }
-
 }

--- a/modules/backend/src/main/scala/smithy4s_codegen/generation/Smithy4s.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/generation/Smithy4s.scala
@@ -1,15 +1,17 @@
 package smithy4s_codegen.generation
 
-import cats.syntax.all._
 import cats.data.NonEmptyList
-import cats.effect.syntax.all._
-import software.amazon.smithy.model.Model
-import scala.jdk.CollectionConverters._
-import smithy4s.codegen._
-import java.nio.file.Path
-import cats.effect.Resource
 import cats.effect.IO
+import cats.effect.Resource
+import cats.effect.syntax.all._
+import cats.syntax.all._
+import smithy4s.codegen._
+import software.amazon.smithy.model.Model
+
+import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
+import scala.jdk.CollectionConverters._
 
 final case class Smithy4sWorkspace(
     input: os.Path,
@@ -17,8 +19,10 @@ final case class Smithy4sWorkspace(
     specs: List[os.Path]
 )
 
-object Smithy4s {
-  def generate(content: String): IO[Vector[(Path, String)]] = {
+final class Smithy4s(localJars: List[File]) {
+  def generate(
+      content: String
+  ): IO[Vector[(Path, String)]] = {
     val prepare = for {
       workspace <- newWorkspace
       _ <- IO.delay(os.makeDir(workspace.input)).toResource
@@ -39,7 +43,7 @@ object Smithy4s {
         dependencies = List.empty,
         repositories = List.empty,
         transformers = List.empty,
-        localJars = List.empty
+        localJars = localJars.map(os.Path(_))
       )
       IO.delay(Codegen.processSpecs(args))
         .flatMap(withContents(workspace.output))

--- a/modules/backend/src/main/scala/smithy4s_codegen/smithy/ModelLoader.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/smithy/ModelLoader.scala
@@ -1,0 +1,76 @@
+package smithy4s_codegen.smithy
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import cats.implicits._
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.loader.ModelAssembler
+import software.amazon.smithy.model.loader.ModelDiscovery
+import software.amazon.smithy.model.loader.ModelManifestException
+import software.amazon.smithy.model.validation.ValidatedResult
+import software.amazon.smithy.model.validation.ValidationEvent
+
+import java.io.File
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters._
+
+class ModelLoader(imports: List[java.net.URL]) {
+  def load(content: String): Either[List[ValidationEvent], Model] = {
+    val res = Model
+      .assembler()
+      .addUnparsedModel("ui.smithy", content)
+      .addImports(imports)
+      .assemble()
+    if (res.isBroken()) Left(res.getValidationEvents().asScala.toList)
+    else Right(res.unwrap())
+  }
+
+  private implicit class ModelAssemblerOps(assembler: ModelAssembler) {
+    def addImports(urls: Seq[java.net.URL]): ModelAssembler = {
+      urls.foreach(assembler.addImport)
+      assembler
+    }
+  }
+}
+
+object ModelLoader {
+  def apply(localJars: List[File]): IO[ModelLoader] = {
+    loadJars(localJars).use {
+      new ModelLoader(_).pure[IO]
+    }
+  }
+
+  private def loadJars(
+      localJars: List[File]
+  ): Resource[IO, List[java.net.URL]] = {
+    localJars
+      .traverse { file =>
+        Resource
+          .fromAutoCloseable(
+            IO.delay(
+              FileSystems.newFileSystem(file.toPath())
+            )
+          )
+          .map { jarFS =>
+            val p = jarFS.getPath("META-INF", "smithy", "manifest")
+
+            // model discovery would throw if we tried to pass a non-existent path
+            if (!Files.exists(p)) Nil
+            else {
+              try ModelDiscovery.findModels(p.toUri().toURL()).asScala.toList
+              catch {
+                case e: ModelManifestException =>
+                  System.err.println(
+                    s"Unexpected exception while loading model from $file, skipping: $e"
+                  )
+                  Nil
+              }
+            }
+          }
+      }
+      .map(_.flatten)
+  }
+}

--- a/modules/backend/src/main/scala/smithy4s_codegen/smithy/Validate.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/smithy/Validate.scala
@@ -1,19 +1,81 @@
 package smithy4s_codegen.smithy
 
 import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import cats.implicits._
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.loader.ModelAssembler
+import software.amazon.smithy.model.loader.ModelDiscovery
+import software.amazon.smithy.model.loader.ModelManifestException
+
+import java.io.File
+import java.nio.file.FileSystems
+import java.nio.file.Files
 import scala.jdk.CollectionConverters._
 
-object Validate {
-  def validateContent(content: String): Either[NonEmptyList[String], Unit] = {
+final class Validate(imports: List[java.net.URL]) {
+  def validateContent(
+      content: String
+  ): IO[Either[NonEmptyList[String], Unit]] = {
     val res =
-      Model.assembler().addUnparsedModel("ui.smithy", content).assemble()
+      Model
+        .assembler()
+        .addUnparsedModel("ui.smithy", content)
+        .addImports(imports)
+        .assemble()
     if (res.isBroken()) {
       val errorList =
         res.getValidationEvents().asScala.toList.map(_.getMessage())
-      Left(NonEmptyList.of(errorList.head, errorList.tail: _*))
+      Left(NonEmptyList.of(errorList.head, errorList.tail: _*)).pure[IO]
     } else {
-      Right(())
+      Right(()).pure[IO]
     }
+  }
+
+  implicit class ModelAssemblerOps(assembler: ModelAssembler) {
+    def addImports(urls: Seq[java.net.URL]): ModelAssembler = {
+      urls.foreach(assembler.addImport)
+      assembler
+    }
+  }
+}
+
+object Validate {
+  def apply(localJars: List[File]): IO[Validate] = {
+    loadJars(localJars).use {
+      new Validate(_).pure[IO]
+    }
+  }
+
+  private def loadJars(
+      localJars: List[File]
+  ): Resource[IO, List[java.net.URL]] = {
+    localJars
+      .traverse { file =>
+        Resource
+          .fromAutoCloseable(
+            IO.delay(
+              FileSystems.newFileSystem(file.toPath())
+            )
+          )
+          .map { jarFS =>
+            val p = jarFS.getPath("META-INF", "smithy", "manifest")
+
+            // model discovery would throw if we tried to pass a non-existent path
+            if (!Files.exists(p)) Nil
+            else {
+              try ModelDiscovery.findModels(p.toUri().toURL()).asScala.toList
+              catch {
+                case e: ModelManifestException =>
+                  System.err.println(
+                    s"Unexpected exception while loading model from $file, skipping: $e"
+                  )
+                  Nil
+              }
+            }
+          }
+      }
+      .map(_.flatten)
   }
 }

--- a/modules/backend/src/main/scala/smithy4s_codegen/smithy/Validate.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/smithy/Validate.scala
@@ -14,68 +14,14 @@ import java.nio.file.FileSystems
 import java.nio.file.Files
 import scala.jdk.CollectionConverters._
 
-final class Validate(imports: List[java.net.URL]) {
+final class Validate(modelLoader: ModelLoader) {
   def validateContent(
       content: String
-  ): IO[Either[NonEmptyList[String], Unit]] = {
-    val res =
-      Model
-        .assembler()
-        .addUnparsedModel("ui.smithy", content)
-        .addImports(imports)
-        .assemble()
-    if (res.isBroken()) {
-      val errorList =
-        res.getValidationEvents().asScala.toList.map(_.getMessage())
-      Left(NonEmptyList.of(errorList.head, errorList.tail: _*)).pure[IO]
-    } else {
-      Right(()).pure[IO]
-    }
-  }
-
-  implicit class ModelAssemblerOps(assembler: ModelAssembler) {
-    def addImports(urls: Seq[java.net.URL]): ModelAssembler = {
-      urls.foreach(assembler.addImport)
-      assembler
-    }
-  }
-}
-
-object Validate {
-  def apply(localJars: List[File]): IO[Validate] = {
-    loadJars(localJars).use {
-      new Validate(_).pure[IO]
-    }
-  }
-
-  private def loadJars(
-      localJars: List[File]
-  ): Resource[IO, List[java.net.URL]] = {
-    localJars
-      .traverse { file =>
-        Resource
-          .fromAutoCloseable(
-            IO.delay(
-              FileSystems.newFileSystem(file.toPath())
-            )
-          )
-          .map { jarFS =>
-            val p = jarFS.getPath("META-INF", "smithy", "manifest")
-
-            // model discovery would throw if we tried to pass a non-existent path
-            if (!Files.exists(p)) Nil
-            else {
-              try ModelDiscovery.findModels(p.toUri().toURL()).asScala.toList
-              catch {
-                case e: ModelManifestException =>
-                  System.err.println(
-                    s"Unexpected exception while loading model from $file, skipping: $e"
-                  )
-                  Nil
-              }
-            }
-          }
-      }
-      .map(_.flatten)
+  ): IO[Either[List[String], Unit]] = {
+    modelLoader
+      .load(content)
+      .leftMap(_.map(_.getMessage()))
+      .map(_ => ())
+      .pure[IO]
   }
 }


### PR DESCRIPTION
Add [APP_SMITHY_CLASSPATH](https://github.com/daddykotex/smithy4s-code-generation/commit/6ab5d53f862a117e5279f1d14f7593de5d66dada) with the hopes of having the classpath configurable to include things likes alloy or other third party dependencies.

Use the internal CodegenImpl to avoid writing to the file system