### PR TITLE
Use monospace font for editor

### DIFF
--- a/modules/frontend/src/main/scala/smithy4s_codegen/components/CodeEditor.scala
+++ b/modules/frontend/src/main/scala/smithy4s_codegen/components/CodeEditor.scala
@@ -36,7 +36,7 @@ class CodeEditor() {
     div(
       cls := "h-full",
       textArea(
-        cls := "block p-2.5 w-full h-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500",
+        cls := "block p-2.5 w-full h-full text-sm text-gray-900 bg-gray-50 rounded-lg border border-gray-300 focus:ring-blue-500 focus:border-blue-500 font-mono",
         value := initial,
         onMountFocus,
         onInput.mapToValue --> codeContent


### PR DESCRIPTION
<img width="889" alt="image" src="https://github.com/daddykotex/smithy4s-code-generation/assets/894884/656b7c47-22b1-4653-8b46-3b109b822a45">

Later on I'd suggest moving to something like CodeMirror or monaco. Either of those could potentially open up the ability to relatively-easily use LSP on the backend for completions and whatnot 😅 