### PR TITLE
Bump smithy4s to 0.18.3

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin(
-  "com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.17.5"
+  "com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.18.3"
 )
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.1")


### PR DESCRIPTION
Seems to work fine: `OperationSchema` is a thing.

<img width="344" alt="image" src="https://github.com/daddykotex/smithy4s-code-generation/assets/894884/4a6d978e-8ee6-4a64-b889-84707f9f4031">
