### PR TITLE
Fix base URL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val frontend = (project in file("modules/frontend"))
       "org.http4s" %%% "http4s-client" % "0.23.16"
     ),
     baseUri := {
-      if (insideCI.value) "" else "http://localhost:9000"
+      if (insideCI.value) "" else "/api"
     },
     buildInfoKeys := Seq[BuildInfoKey](baseUri),
     buildInfoPackage := "smithy4s_codegen",

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,10 @@ lazy val frontend = (project in file("modules/frontend"))
       "org.http4s" %%% "http4s-client" % "0.23.16"
     ),
     baseUri := {
-      if (insideCI.value) "" else "/api"
+      if (insideCI.value) ""
+      else
+        // Vite will proxy this to the backend. See vite.config.js
+        "/api"
     },
     buildInfoKeys := Seq[BuildInfoKey](baseUri),
     buildInfoPackage := "smithy4s_codegen",

--- a/modules/backend/src/main/scala/smithy4s_codegen/Main.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/Main.scala
@@ -46,7 +46,6 @@ class SmithyCodeGenerationServiceImpl(generator: Smithy4s, validator: Validate)
 }
 
 object Routes {
-  import org.http4s.server.middleware.CORS
   def exampleRoute(localJars: List[File]): Resource[IO, HttpRoutes[IO]] =
     Resource
       .eval(ModelLoader(localJars))
@@ -55,7 +54,6 @@ object Routes {
         SimpleRestJsonBuilder
           .routes(new SmithyCodeGenerationServiceImpl(generator, validator))
           .resource
-          .map(CORS(_))
       }
 
   private val docs: HttpRoutes[IO] =

--- a/modules/backend/src/main/scala/smithy4s_codegen/Main.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/Main.scala
@@ -18,7 +18,6 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 import scala.concurrent.duration._
-import org.http4s.server.middleware.Logger
 
 class SmithyCodeGenerationServiceImpl(generator: Smithy4s, validator: Validate)
     extends SmithyCodeGenerationService[IO] {
@@ -100,13 +99,7 @@ object Main extends IOApp.Simple {
         .default[IO]
         .withPort(thePort)
         .withHost(theHost)
-        .withHttpApp(
-          Logger.httpApp(
-            logHeaders = true,
-            logBody = true,
-            logAction = Some(IO.println(_: String))
-          )(routes.orNotFound)
-        )
+        .withHttpApp(routes.orNotFound)
         .withShutdownTimeout(5.seconds)
         .build
     _ <- Resource.eval(IO.println(s"Server started on: $theHost:$thePort"))

--- a/modules/backend/src/main/scala/smithy4s_codegen/Main.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/Main.scala
@@ -18,6 +18,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
 import scala.concurrent.duration._
+import org.http4s.server.middleware.Logger
 
 class SmithyCodeGenerationServiceImpl(generator: Smithy4s, validator: Validate)
     extends SmithyCodeGenerationService[IO] {
@@ -99,7 +100,13 @@ object Main extends IOApp.Simple {
         .default[IO]
         .withPort(thePort)
         .withHost(theHost)
-        .withHttpApp(routes.orNotFound)
+        .withHttpApp(
+          Logger.httpApp(
+            logHeaders = true,
+            logBody = true,
+            logAction = Some(IO.println(_: String))
+          )(routes.orNotFound)
+        )
         .withShutdownTimeout(5.seconds)
         .build
     _ <- Resource.eval(IO.println(s"Server started on: $theHost:$thePort"))

--- a/modules/frontend/src/main/scala/smithy4s_codegen/Main.scala
+++ b/modules/frontend/src/main/scala/smithy4s_codegen/Main.scala
@@ -10,7 +10,6 @@ import org.http4s.client.Client
 import org.http4s.dom.FetchClientBuilder
 import org.scalajs.dom
 import smithy4s.http4s.SimpleRestJsonBuilder
-import smithy4s_codegen.BuildInfo.baseUri
 import smithy4s_codegen.api.SmithyCodeGenerationService
 import smithy4s_codegen.components.pages.Home
 

--- a/modules/frontend/src/main/scala/smithy4s_codegen/components/pages/Home.scala
+++ b/modules/frontend/src/main/scala/smithy4s_codegen/components/pages/Home.scala
@@ -2,7 +2,6 @@ package smithy4s_codegen.components.pages
 
 import com.raquo.laminar.api.L._
 import org.scalajs.dom.ext.Ajax.InputData
-import smithy4s_codegen.BuildInfo.baseUri
 import smithy4s_codegen.api.Smithy4sConvertInput
 import smithy4s_codegen.api.Smithy4sConvertOutput
 import smithy4s_codegen.api.SmithyCodeGenerationService
@@ -29,7 +28,7 @@ object Home {
             .recover {
               case InvalidSmithyContent(errors) =>
                 Some(CodeEditor.ValidationResult.Failed(errors))
-              case ex: Throwable =>
+              case ex =>
                 Some(CodeEditor.ValidationResult.UnknownFailure(ex))
             }
         }
@@ -45,7 +44,7 @@ object Home {
               .map(r =>
                 CodeEditor.Smithy4sConversionResult.Success(r.generated)
               )
-              .recover { case ex: Throwable =>
+              .recover { ex =>
                 Some(CodeEditor.Smithy4sConversionResult.UnknownFailure(ex))
               }
           }

--- a/modules/frontend/vite.config.js
+++ b/modules/frontend/vite.config.js
@@ -8,4 +8,12 @@ export default defineConfig({
       projectID: "frontend",
     }),
   ],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:9000",
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
+  },
 });

--- a/modules/frontend/vite.config.js
+++ b/modules/frontend/vite.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
   ],
   server: {
     proxy: {
+      // For requests to /api/**, drop the prefix and proxy the rest to the backend.
       "/api": {
         target: "http://localhost:9000",
         rewrite: (path) => path.replace(/^\/api/, ""),


### PR DESCRIPTION
This solves the problem mentioned in https://github.com/daddykotex/smithy4s-code-generation/pull/12#issuecomment-1799772389 by applying the workaround from https://github.com/disneystreaming/smithy4s/issues/1245#issuecomment-1751145705.

In addition, to avoid having to deal with multiple origins, I made the base URL start with `/api` for local development, and requests to that path will be proxied by Vite to the local backend. This removes the need to handle CORS.