### PR TITLE
Load custom Smithy classpath

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
           java-version: 17
           cache: sbt
 
-      - run: sbt "test; backend / Docker / publishLocal"
+      - run: sbt "test"
+
+      - run: ./scripts/build-image.sh
+        env:
+          PUBLISH_OFFICIAL: "false"
 
       - name: Compress target directories
         run: tar cf targets.tar target project/target
@@ -71,6 +75,8 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_TOKEN }}
       - run: ./scripts/build-image.sh
+        env:
+          PUBLISH_OFFICIAL: "true"
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# Generate Smithy4s code on the fly
+# Generate Smithy4s code on the fly <!-- omit in toc -->
+
+- [Modules](#modules)
+  - [Backend](#backend)
+    - [Configuration](#configuration)
+  - [Frontend](#frontend)
+  - [Developement](#developement)
+- [Dockerhub](#dockerhub)
+- [Fly.io](#flyio)
+
 
 ## Modules
 
@@ -9,6 +18,12 @@ Full stack Scala application with a Scalajs frontend. Depends on [Frontend](#fro
 Live at: https://morning-bird-7081.fly.dev/
 
 Deployed on a very small 2vcpu and 512mb vm.
+
+#### Configuration
+
+The backend can be configured.
+
+1. `SMITHY_CLASSPATH_CONFIG`: location of a json file used to load dependencies to include during code gen
 
 ### Frontend
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ It is recomended that you have 3 long running proccesses to develop this applica
 
 The images are pushed to the [docker hub](https://hub.docker.com/repository/docker/daddykotex/smithy4s-code-generation/general) so you can deploy them on your own infrastructure.
 
+* latest: daddykotex/smithy4s-code-generation:latest
+* latest: daddykotex/smithy4s-code-generation:with-dependencies
+* daddykotex/smithy4s-code-generation:$SHA
+* daddykotex/smithy4s-code-generation:with-dependencies-$SHA
+
 ## Fly.io
 
 The images are pushed to the fly.io registry so that it can be deployed quickly from there.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,15 @@ Deployed on a very small 2vcpu and 512mb vm.
 
 The backend can be configured.
 
-1. `SMITHY_CLASSPATH_CONFIG`: location of a json file used to load dependencies to include during code gen
+1. `SMITHY_CLASSPATH_CONFIG`: location of a json file used to load dependencies to include during code gen. The file looks content looks like this:
+
+```json
+{
+  "entries": {
+    "com.disneystreaming.alloy:alloy-core:0.2.8": "/opt/docker/smithy-classpath/alloy-core-0.2.8.jar"
+  }
+}
+```
 
 ### Frontend
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,10 @@ ThisBuild / organization := "com.example"
 ThisBuild / organizationName := "example"
 ThisBuild / scalaVersion := "2.13.10"
 
+val http4sVersion = "0.23.24"
+val smithyVersion = "1.41.1"
+val cirisVersion = "3.5.0"
+
 lazy val baseUri = settingKey[String](
   """Base URI of the backend, defaults to `""` (empty string)."""
 )
@@ -46,7 +50,7 @@ lazy val frontend = (project in file("modules/frontend"))
       "com.raquo" %%% "laminar" % "16.0.0",
       "com.disneystreaming.smithy4s" %%% "smithy4s-http4s" % smithy4sVersion.value,
       "org.http4s" %%% "http4s-dom" % "0.2.3",
-      "org.http4s" %%% "http4s-client" % "0.23.16"
+      "org.http4s" %%% "http4s-client" % http4sVersion
     ),
     baseUri := {
       if (bundleAssets.value) ""
@@ -71,8 +75,9 @@ lazy val backend = (project in file("modules/backend"))
       "com.disneystreaming.smithy4s" %% "smithy4s-http4s" % smithy4sVersion.value,
       "com.disneystreaming.smithy4s" %% "smithy4s-http4s-swagger" % smithy4sVersion.value,
       "com.disneystreaming.smithy4s" %% "smithy4s-codegen" % smithy4sVersion.value,
-      "software.amazon.smithy" % "smithy-model" % "1.30.0",
-      "org.http4s" %% "http4s-ember-server" % "0.23.16"
+      "is.cir" %% "ciris" % cirisVersion,
+      "software.amazon.smithy" % "smithy-model" % smithyVersion,
+      "org.http4s" %% "http4s-ember-server" % http4sVersion
     ),
     Compile / resourceGenerators += Def.task {
       val dir = frontend.base

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ ThisBuild / scalaVersion := "2.13.10"
 
 val http4sVersion = "0.23.24"
 val smithyVersion = "1.41.1"
+val circeVersion = "0.14.1"
 val cirisVersion = "3.5.0"
 
 lazy val baseUri = settingKey[String](
@@ -75,6 +76,9 @@ lazy val backend = (project in file("modules/backend"))
       "com.disneystreaming.smithy4s" %% "smithy4s-http4s" % smithy4sVersion.value,
       "com.disneystreaming.smithy4s" %% "smithy4s-http4s-swagger" % smithy4sVersion.value,
       "com.disneystreaming.smithy4s" %% "smithy4s-codegen" % smithy4sVersion.value,
+      "io.circe" %% "circe-core" % circeVersion,
+      "io.circe" %% "circe-generic" % circeVersion,
+      "io.circe" %% "circe-parser" % circeVersion,
       "is.cir" %% "ciris" % cirisVersion,
       "software.amazon.smithy" % "smithy-model" % smithyVersion,
       "org.http4s" %% "http4s-ember-server" % http4sVersion

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,6 @@
 import org.scalajs.linker.interface.ModuleSplitStyle
+import com.typesafe.sbt.packager.docker._
+import smithy4s_codegen._
 
 ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / organization := "com.example"
@@ -13,6 +15,7 @@ val cirisVersion = "3.5.0"
 lazy val baseUri = settingKey[String](
   """Base URI of the backend, defaults to `""` (empty string)."""
 )
+
 lazy val bundleAssets = settingKey[Boolean](
   """Whether or not assets should be bundled in the backend jar"""
 )
@@ -21,8 +24,15 @@ ThisBuild / bundleAssets := sys.env
   .map(_.toBoolean)
   .getOrElse(false)
 
+lazy val smithyClasspath = settingKey[Seq[ModuleID]](
+  """List of artifacts to include in backend image that has dependencies"""
+)
+lazy val smithyClasspathDir = settingKey[String](
+  """Path of the smithy classpath directory (where we mount the config and the jars)"""
+)
+
 lazy val root = (project in file("."))
-  .aggregate(api, frontend, backend)
+  .aggregate(api, frontend, backend, backendDependencies)
 
 lazy val api = (project in file("modules/api"))
 
@@ -106,16 +116,99 @@ lazy val backend = (project in file("modules/backend"))
     Docker / dockerExposedPorts := List(9000),
     Docker / packageName := "smithy4s-code-generation",
     Docker / dockerRepository := Some("daddykotex"),
-    dockerAliases ++= Seq(
-      dockerAlias.value.withTag(sys.env.get("GITHUB_SHA")),
-      dockerAlias.value
-        .withName("morning-bird-7081")
-        .withRegistryHost(Option("registry.fly.io")),
-      dockerAlias.value
-        .withTag(sys.env.get("GITHUB_SHA"))
-        .withName("morning-bird-7081")
-        .withRegistryHost(Option("registry.fly.io"))
-    ),
+    dockerAliases ++= {
+      val sha = sys.env.get("GITHUB_SHA").map(_.take(10))
+      val latests = Seq(
+        dockerAlias.value
+          .withName("morning-bird-7081")
+          .withRegistryHost(Option("registry.fly.io"))
+      )
+      val shas = sha.toSeq.flatMap { s =>
+        Seq(
+          dockerAlias.value.withTag(Some(s)),
+          dockerAlias.value
+            .withTag(Some(s))
+            .withName("morning-bird-7081")
+            .withRegistryHost(Option("registry.fly.io"))
+        )
+      }
+
+      latests ++ shas
+    },
     Docker / version := "latest",
     dockerBaseImage := "eclipse-temurin:17.0.6_10-jre"
+  )
+
+/** This is a project that's only intented to be a copy of backend but that
+  * builds in an image with some dependencies for the smithy-classpath.
+  */
+lazy val backendDependencies = project
+  .enablePlugins(DockerPlugin)
+  .settings(
+    smithyClasspath := Seq(
+      "com.disneystreaming.alloy" % "alloy-core" % "0.2.8"
+    ),
+    Universal / mappings := {
+      val depRes = dependencyResolution.value
+      val artifacts = smithyClasspath.value
+      val smithyClasspathOutput = target.value / "smithy-classpath"
+      val logger = sLog.value
+      val resolved = artifacts.flatMap { module =>
+        depRes.retrieve(module, None, target.value, logger) match {
+          case Left(value) =>
+            sys.error(s"Unable to resolve smithy classpath module $module")
+          case Right(value) => value.headOption.map(f => module -> f)
+        }
+      }
+      val smithyClasspathValue = smithyClasspathDir.value
+
+      val entries: Seq[SmithyClasspathEntry] =
+        resolved.map { case (module, file) =>
+          SmithyClasspathEntry(
+            module,
+            file,
+            s"$smithyClasspathValue/${file.name}"
+          )
+        }
+      val entriesMapping =
+        entries.map { case SmithyClasspathEntry(_, file, pathInImage) =>
+          file -> pathInImage
+        }
+
+      val smithyClasspathFile = target.value / "smithy-classpath.json"
+      SmithyClasspath.toFile(
+        smithyClasspathFile,
+        entries,
+        (Docker / defaultLinuxInstallLocation).value
+      )
+      val configMapping = Seq(
+        smithyClasspathFile -> s"$smithyClasspathValue/smithy-classpath.json"
+      )
+      entriesMapping ++ configMapping
+    },
+    dockerAliases := {
+      val beAlias = (backend / dockerAlias).value
+      val sha = sys.env.get("GITHUB_SHA").map(_.take(10))
+      val tags =
+        sha.map(s => s"with-dependencies-$s").toSeq ++ Seq("with-dependencies")
+      tags.flatMap { t =>
+        Seq(
+          dockerAlias.value.withTag(Some(t)),
+          dockerAlias.value
+            .withTag(Some(t))
+            .withName("morning-bird-7081")
+            .withRegistryHost(Option("registry.fly.io"))
+        )
+      }
+    },
+    dockerEntrypoint := (backend / dockerEntrypoint).value,
+    dockerBaseImage := (backend / dockerAlias).value.toString,
+    smithyClasspathDir := "smithy-classpath",
+    dockerEnvVars ++= {
+      val inDockerPath = (Docker / defaultLinuxInstallLocation).value
+      val smithyClasspathValue = smithyClasspathDir.value
+      Map(
+        "SMITHY_CLASSPATH_CONFIG" -> s"$inDockerPath/$smithyClasspathValue/smithy-classpath.json"
+      )
+    }
   )

--- a/modules/api/src/main/resources/META-INF/smithy/SmithyCodeGenerationService.smithy
+++ b/modules/api/src/main/resources/META-INF/smithy/SmithyCodeGenerationService.smithy
@@ -9,16 +9,27 @@ service SmithyCodeGenerationService {
     version: "1.0.0"
     operations: [
         HealthCheck
+        GetConfiguration
         SmithyValidate
         Smithy4sConvert
     ]
 }
 
 @http(method: "GET", uri: "/health", code: 200)
+@readonly
 operation HealthCheck {
     output := {
         @required
         message: String
+    }
+}
+
+@http(method: "GET", uri: "/configuration", code: 200)
+@readonly
+operation GetConfiguration {
+    output := {
+        @required
+        availableDependencies: Dependencies
     }
 }
 
@@ -27,6 +38,8 @@ operation SmithyValidate {
     input := {
         @required
         content: String
+        @documentation("If omitted, use the server's default.")
+        deps: Dependencies
     }
     errors: [InvalidSmithyContent]
 }
@@ -47,6 +60,8 @@ operation Smithy4sConvert {
     input := {
         @required
         content: String
+        @documentation("If omitted, use the server's default.")
+        deps: Dependencies
     }
     output := {
         @required
@@ -62,4 +77,10 @@ string Content
 map Smithy4sGeneratedContent {
     key: Path
     value: Content
+}
+
+string Dependency
+
+list Dependencies {
+    member: Dependency
 }

--- a/modules/backend/src/main/scala/smithy4s_codegen/Config.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/Config.scala
@@ -1,0 +1,75 @@
+package smithy4s_codegen
+
+import ciris._
+import fs2.io.file.{Path => FPath}
+import cats.implicits._
+import fs2.io.file.Files
+import cats.effect.IO
+import io.circe._, io.circe.generic.semiauto._
+
+final class InvalidConfiguration(message: String)
+    extends RuntimeException(message)
+
+final case class SmithyClasspathConfig(
+    entries: Map[String, FPath]
+)
+
+private final case class JsonSmithyClasspathConfig(
+    entries: Map[String, String]
+)
+
+private object JsonSmithyClasspathConfig {
+  implicit val decoder: Decoder[JsonSmithyClasspathConfig] =
+    deriveDecoder[JsonSmithyClasspathConfig]
+}
+
+final case class Config(
+    smithyClasspathConfig: SmithyClasspathConfig
+)
+
+object Config {
+  private def asFPath(_path: String) = {
+    val path = FPath(_path)
+    Files[IO]
+      .exists(path)
+      .ifM(
+        path.pure[IO],
+        IO.raiseError(
+          new IllegalArgumentException(
+            s"File at ${_path} does not exist."
+          )
+        )
+      )
+  }
+
+  private def loadSmithyClasspathConfig(path: FPath) = {
+    Files[IO]
+      .readUtf8(path)
+      .compile
+      .lastOrError
+      .flatMap { payload =>
+        parser.decode[JsonSmithyClasspathConfig](payload).liftTo[IO]
+      }
+      .flatMap { jsonConfig =>
+        jsonConfig.entries.toList
+          .traverse { case (dep, jar) =>
+            asFPath(jar).tupleLeft(dep)
+          }
+          .map(_.toMap)
+          .map(SmithyClasspathConfig)
+      }
+  }
+
+  val smithyClasspathConfigFile =
+    env("SMITHY_CLASSPATH_CONFIG")
+      .default("./smithy-classpath.json")
+      .evalMap { asFPath }
+
+  val smithyClasspathConfig = smithyClasspathConfigFile
+    .evalMap { loadSmithyClasspathConfig }
+
+  val config = smithyClasspathConfig.map(Config.apply)
+
+  val makeConfig = config.load[IO]
+
+}

--- a/modules/backend/src/main/scala/smithy4s_codegen/generation/Smithy4s.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/generation/Smithy4s.scala
@@ -8,10 +8,11 @@ case class CodegenResult(namespace: String, name: String, content: String)
 
 final class Smithy4s(modelLoader: ModelLoader) {
   def generate(
+      dependencies: List[String],
       content: String
   ): Either[List[ValidationEvent], List[(os.RelPath, CodegenResult)]] = {
     modelLoader
-      .load(List.empty, content) // TODO fix
+      .load(dependencies, content)
       .map(model => CodegenTrick.run(model, None, None))
   }
 }

--- a/modules/backend/src/main/scala/smithy4s_codegen/generation/Smithy4s.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/generation/Smithy4s.scala
@@ -11,7 +11,7 @@ final class Smithy4s(modelLoader: ModelLoader) {
       content: String
   ): Either[List[ValidationEvent], List[(os.RelPath, CodegenResult)]] = {
     modelLoader
-      .load(content)
+      .load(List.empty, content) // TODO fix
       .map(model => CodegenTrick.run(model, None, None))
   }
 }

--- a/modules/backend/src/main/scala/smithy4s_codegen/smithy/ModelLoader.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/smithy/ModelLoader.scala
@@ -3,6 +3,8 @@ package smithy4s_codegen.smithy
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import cats.implicits._
+import fs2.io.file.{Path => FPath}
+import smithy4s_codegen.SmithyClasspathConfig
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.loader.ModelAssembler
 import software.amazon.smithy.model.loader.ModelDiscovery
@@ -14,12 +16,17 @@ import java.nio.file.FileSystems
 import java.nio.file.Files
 import scala.jdk.CollectionConverters._
 
-class ModelLoader(imports: List[java.net.URL]) {
-  def load(content: String): Either[List[ValidationEvent], Model] = {
+class ModelLoader(allImports: Map[String, List[java.net.URL]]) {
+  def load(
+      dependencies: List[String],
+      content: String
+  ): Either[List[ValidationEvent], Model] = {
+    val depImports =
+      dependencies.flatMap(dep => allImports.get(dep).toList.flatten)
     val res = Model
       .assembler()
       .addUnparsedModel("ui.smithy", content)
-      .addImports(imports)
+      .addImports(depImports)
       .assemble()
     if (res.isBroken()) Left(res.getValidationEvents().asScala.toList)
     else Right(res.unwrap())
@@ -34,40 +41,46 @@ class ModelLoader(imports: List[java.net.URL]) {
 }
 
 object ModelLoader {
-  def apply(localJars: List[File]): IO[ModelLoader] = {
-    loadJars(localJars).use {
-      new ModelLoader(_).pure[IO]
-    }
+  def apply(smithyClasspathConfig: SmithyClasspathConfig): IO[ModelLoader] = {
+    loadJars(smithyClasspathConfig).map(new ModelLoader(_))
+  }
+
+  private def smithyUrls(jar: FPath): IO[List[java.net.URL]] = {
+    Resource
+      .fromAutoCloseable(
+        IO.delay(
+          FileSystems.newFileSystem(jar.toNioPath)
+        )
+      )
+      .use { jarFS =>
+        val p = jarFS.getPath("META-INF", "smithy", "manifest")
+
+        // model discovery would throw if we tried to pass a non-existent path
+        if (!Files.exists(p)) IO.pure(Nil)
+        else {
+          try {
+            IO.delay(
+              ModelDiscovery.findModels(p.toUri().toURL()).asScala.toList
+            )
+          } catch {
+            case e: ModelManifestException =>
+              IO.delay(
+                System.err.println(
+                  s"Unexpected exception while loading model from $jar, skipping: $e"
+                )
+              ).as(Nil)
+          }
+        }
+      }
   }
 
   private def loadJars(
-      localJars: List[File]
-  ): Resource[IO, List[java.net.URL]] = {
-    localJars
-      .traverse { file =>
-        Resource
-          .fromAutoCloseable(
-            IO.delay(
-              FileSystems.newFileSystem(file.toPath())
-            )
-          )
-          .map { jarFS =>
-            val p = jarFS.getPath("META-INF", "smithy", "manifest")
-
-            // model discovery would throw if we tried to pass a non-existent path
-            if (!Files.exists(p)) Nil
-            else {
-              try ModelDiscovery.findModels(p.toUri().toURL()).asScala.toList
-              catch {
-                case e: ModelManifestException =>
-                  System.err.println(
-                    s"Unexpected exception while loading model from $file, skipping: $e"
-                  )
-                  Nil
-              }
-            }
-          }
+      smithyClasspathConfig: SmithyClasspathConfig
+  ): IO[Map[String, List[java.net.URL]]] = {
+    smithyClasspathConfig.entries.toList
+      .traverse { case (coordinate, jar) =>
+        smithyUrls(jar).tupleLeft(coordinate)
       }
-      .map(_.flatten)
+      .map(_.toMap)
   }
 }

--- a/modules/backend/src/main/scala/smithy4s_codegen/smithy/Validate.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/smithy/Validate.scala
@@ -8,7 +8,7 @@ final class Validate(modelLoader: ModelLoader) {
       content: String
   ): IO[Either[List[String], Unit]] = {
     modelLoader
-      .load(content)
+      .load(List.empty, content)
       .leftMap(_.map(_.getMessage()))
       .map(_ => ())
       .pure[IO]

--- a/modules/backend/src/main/scala/smithy4s_codegen/smithy/Validate.scala
+++ b/modules/backend/src/main/scala/smithy4s_codegen/smithy/Validate.scala
@@ -5,10 +5,11 @@ import cats.implicits._
 
 final class Validate(modelLoader: ModelLoader) {
   def validateContent(
+      dependencies: List[String],
       content: String
   ): IO[Either[List[String], Unit]] = {
     modelLoader
-      .load(List.empty, content)
+      .load(dependencies, content)
       .leftMap(_.map(_.getMessage()))
       .map(_ => ())
       .pure[IO]

--- a/modules/frontend/src/main/scala/smithy4s_codegen/Main.scala
+++ b/modules/frontend/src/main/scala/smithy4s_codegen/Main.scala
@@ -15,7 +15,8 @@ object Main extends IOApp.Simple {
 
   private def setup(api: SmithyCodeGenerationService[EventStream]) = IO.delay {
     lazy val appContainer = dom.document.querySelector("#app") // must be lazy
-    val appElement = Home(api)
+    val appElement =
+      Home(api, api.getConfiguration().recoverToTry.map(_.toEither))
     render(appContainer, appElement)
   }
   val run = ApiBuilder.build.flatMap(setup(_).toResource).useForever

--- a/modules/frontend/src/main/scala/smithy4s_codegen/components/CodeEditor.scala
+++ b/modules/frontend/src/main/scala/smithy4s_codegen/components/CodeEditor.scala
@@ -110,8 +110,7 @@ class CodeEditor(dependencies: EventStream[Either[Throwable, Dependencies]]) {
         controlled(
           updateValueFromPermalinkCode,
           updatePermalinkCode
-        ),
-        PermalinkCodec.read --> editorContent
+        )
       ),
       div(
         cls := "block p-2.5 w-full h-1/6",

--- a/modules/frontend/src/main/scala/smithy4s_codegen/components/CodeEditor.scala
+++ b/modules/frontend/src/main/scala/smithy4s_codegen/components/CodeEditor.scala
@@ -196,7 +196,11 @@ object PermalinkCodec {
       val deps =
         hashParts
           .collectFirst { case depsPart(value) =>
-            value.split(",").toSet.map(Dependency(_))
+            value
+              .split(",")
+              .filter(_.nonEmpty)
+              .toSet
+              .map(Dependency(_))
           }
           .getOrElse(Set.empty)
       maybeCode.map(code => EditorContent(code, deps))

--- a/modules/frontend/src/main/scala/smithy4s_codegen/components/pages/Home.scala
+++ b/modules/frontend/src/main/scala/smithy4s_codegen/components/pages/Home.scala
@@ -2,17 +2,18 @@ package smithy4s_codegen.components.pages
 
 import com.raquo.airstream.ownership.ManualOwner
 import com.raquo.laminar.api.L._
-import smithy4s_codegen.api.SmithyCodeGenerationService
+import smithy4s_codegen.api._
 import smithy4s_codegen.components.CodeEditor
 import smithy4s_codegen.components.CodeEditor.ValidationResult
 import smithy4s_codegen.components.CodeViewer
-
-import smithy4s_codegen.api.InvalidSmithyContent
 import smithy4s_codegen.components.PermalinkCodec
 
 object Home {
-  def apply(api: SmithyCodeGenerationService[EventStream]) = {
-    val editor = new CodeEditor()
+  def apply(
+      api: SmithyCodeGenerationService[EventStream],
+      config: EventStream[Either[Throwable, GetConfigurationOutput]]
+  ) = {
+    val editor = new CodeEditor(config.map(_.map(_.availableDependencies)))
     val viewer = new CodeViewer()
 
     locally {

--- a/project/SmithyClasspath.scala
+++ b/project/SmithyClasspath.scala
@@ -1,0 +1,33 @@
+package smithy4s_codegen
+
+import sbt.librarymanagement.ModuleID
+import sbt.librarymanagement.Disabled
+import java.io.File
+import sbt.io.IO
+
+final case class SmithyClasspathEntry(
+    module: sbt.ModuleID,
+    file: File,
+    relativePath: String
+)
+object SmithyClasspath {
+  def toFile(
+      target: File,
+      all: Seq[SmithyClasspathEntry],
+      dockerPath: String
+  ): Unit = {
+    val entries = all.map { sce =>
+      encodeModule(sce.module) -> ujson.Str(s"$dockerPath/${sce.relativePath}")
+    }.toMap
+    val content = ujson.Obj(
+      "entries" -> ujson.Obj.from(entries)
+    )
+    IO.write(target, content.render())
+  }
+
+  private def encodeModule(m: ModuleID): String = {
+    m.crossVersion match {
+      case Disabled => s"${m.organization}:${m.name}:${m.revision}"
+    }
+  }
+}

--- a/project/deps.sbt
+++ b/project/deps.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "com.lihaoyi" %% "upickle" % "3.1.3"

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 
-set -euo pipefail
+set -eo pipefail
 
 export BUNDLE_ASSETS="true"
 
+if [[ "$PUBLISH_OFFICIAL" == "true" ]]; then
+    BACKEND_PUBLISH="publish"
+else
+    BACKEND_PUBLISH="publishLocal"
+fi
+
+set -u
+
 (cd modules/frontend; npm i && npm run build)
-sbt "backend / Docker / publish"
+sbt "backend / Docker / $BACKEND_PUBLISH; backendDependencies / Docker / $BACKEND_PUBLISH"

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -1,8 +1,13 @@
 {
+  "version": "1.0",
   "maven": {
     "dependencies": [
       "com.disneystreaming.smithy4s:smithy4s-protocol:0.18.3",
       "com.disneystreaming.alloy:alloy-core:0.2.8"
     ]
-  }
+  },
+  "imports": [
+    "modules/frontend/src/main/smithy",
+    "modules/frontend/target/scala-2.13/src_managed/main/smithy"
+  ]
 }

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -1,8 +1,8 @@
 {
   "maven": {
     "dependencies": [
-      "com.disneystreaming.smithy4s:smithy4s-protocol:0.17.5",
-      "com.disneystreaming.alloy:alloy-core:0.1.2"
+      "com.disneystreaming.smithy4s:smithy4s-protocol:0.18.3",
+      "com.disneystreaming.alloy:alloy-core:0.2.8"
     ]
   }
 }


### PR DESCRIPTION
Fixes https://github.com/daddykotex/smithy4s-code-generation/issues/15

- [x] Docs - waiting on some discussion to see if the design will change before adding that
- [ ] Tests - same as above

The app configuration now reads from a JSON file to configure the classpath for the code generation. I've decided to do it at build time / deployment time as opposed to runtime (via an embedded coursier) for a few reason:

- you don't deploy an app that has unresolvable dependencies
- can't be messed around to load potentially unsafe jars (if you bundled them in your deployment, you can vet them and you're sure nothing else ends up on the classpath)
- you resolve jars once when you build/deploy the app

The file is expected to look like that:

```json
{
  "entries": {
    "com.disneystreaming.alloy:alloy-core:0.2.8": "/path/to/Coursier/v1/https/repo1.maven.org/maven2/com/disneystreaming/alloy/alloy-core/0.2.8/alloy-core-0.2.8.jar",
    "software.amazon.smithy:smithy-aws-iam-traits:1.41.1": "/path/to/Coursier/v1/https/repo1.maven.org/maven2/software/amazon/smithy/smithy-aws-iam-traits/1.41.1/smithy-aws-iam-traits-1.41.1.jar"
  }
}
```

If this file is available, then the UI is customized a little bit to show checkboxes for all the dependencies available. The permalink also takes it into account.

URL looks like:

http://localhost:5173/#code=CQNwpgTgzglg9gOwFwAIBEAmNAobCCGAtmFAA74DGYKMCpArgC64AC+ANu3AJ4DE99GABMAYnAiF8zKIwi0A5igCSAEVwyI9Co3oRqABUhREKAN7YUKFnoCOgvUIs0hqVU+tg7MB04LFUAMqyCtgAvkA;dependencies=com.disneystreaming.alloy:alloy-core:0.2.8

![Screenshot 2023-12-08 at 10 40 26](https://github.com/daddykotex/smithy4s-code-generation/assets/5230460/40e0f4c5-985d-4bc2-823b-a76b3c486cdc)
