### PR TITLE
Tweak build

### DIFF
--- a/.github/workflows/bundlemon.yml
+++ b/.github/workflows/bundlemon.yml
@@ -23,7 +23,10 @@ jobs:
           java-version: 17
           cache: sbt
 
-      - run: sbt "frontend/buildFrontend"
+      - run: |
+          npm install
+          npm run build
+        working-directory: ./modules/frontend
 
       - name: Run BundleMon
         working-directory: ./modules/frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       - run: flyctl auth docker
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_TOKEN }}
-      - run: sbt "backend / Docker / publish"
+      - run: ./scripts/build-image.sh
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ metals.sbt
 
 # VS-Code
 .vscode/
+
+# smithy-lsp
+build/smithy/

--- a/README.md
+++ b/README.md
@@ -19,13 +19,16 @@ ScalaJS application shipped in [Backend](#backend).
 It is recomended that you have 3 long running proccesses to develop this application:
 
 1. backend: `sbt ~backend/reStart`
-2. frontend scalajs: `sbt "~frontend/fastLinkJS"`
-3. cd into `modules/frontend` and run `npm i && npm run dev`
+2. cd into `modules/frontend` and run `npm i && npm run dev`
+3. frontend scalajs: `sbt "~frontend/fastLinkJS"`
 
-You could drop 3 if you've built it once and your backend is running serving the generated frontend assets.
+## Dockerhub
 
+The images are pushed to the [docker hub](https://hub.docker.com/repository/docker/daddykotex/smithy4s-code-generation/general) so you can deploy them on your own infrastructure.
 
 ## Fly.io
+
+The images are pushed to the fly.io registry so that it can be deployed quickly from there.
 
 Use the following command to use the right version of flyctl via nix:
 `nix-shell -p flyctl -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/555bd32eb477d657e133ad14a5f99ac685bfdd61.tar.gz`

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export BUNDLE_ASSETS="true"
+
+(cd modules/frontend; npm i && npm run build)
+sbt "backend / Docker / publish"


### PR DESCRIPTION
I hate working in the backend and seeing the frontend being rebuilt all the time.

Instead I did the following:

1. in development, you use the backend for the api, but vite will host the frontend and proxy the request to the backend
2. when you build the docker, it is assumed that you ran `npm run build` in the modules/frontend project so that they can be bundled