### PR TITLE
Add smithy4s-protocol to classpath deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Deployed on a very small 2vcpu and 512mb vm.
 
 The backend can be configured.
 
-1. `SMITHY_CLASSPATH_CONFIG`: location of a json file used to load dependencies to include during code gen. The file looks content looks like this:
+1. `SMITHY_CLASSPATH_CONFIG`: location of a json file used to load dependencies to include during code gen. The file content looks like this:
 
 ```json
 {

--- a/build.sbt
+++ b/build.sbt
@@ -198,7 +198,8 @@ lazy val backendDependencies = project
   .settings(smithyClasspathSettings)
   .settings(
     smithyClasspath := Seq(
-      "com.disneystreaming.alloy" % "alloy-core" % "0.2.8"
+      "com.disneystreaming.alloy" % "alloy-core" % "0.2.8",
+      "com.disneystreaming.smithy4s" % "smithy4s-protocol" % smithy4sVersion.value
     ),
     smithyClasspathDir := "smithy-classpath",
     Docker / packageName := "smithy4s-code-generation",

--- a/modules/frontend/src/main/scala/smithy4s_codegen/components/CodeEditor.scala
+++ b/modules/frontend/src/main/scala/smithy4s_codegen/components/CodeEditor.scala
@@ -91,7 +91,7 @@ class CodeEditor(dependencies: EventStream[Either[Throwable, Dependencies]]) {
                   updatePermalinkDeps(dep),
                   updateCheckFromPermalinkDeps(dep)
                 ),
-                label(forId := dep.value, dep.value)
+                label(forId := dep.value, dep.value, cls := "font-mono")
               )
             }
           )


### PR DESCRIPTION
It enables using things like `smithy4s.meta#adt` and other smithy4s codegen customizations.

In addition, adding a monospace class for the dependency strings.