### PR TITLE
Tweak the deployment to improve local dev experience

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,10 +2,10 @@ import org.scalajs.linker.interface.ModuleSplitStyle
 import com.typesafe.sbt.packager.docker._
 import smithy4s_codegen._
 
-ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / organization := "com.example"
 ThisBuild / organizationName := "example"
 ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / dynverSeparator := "-"
 
 val http4sVersion = "0.23.24"
 val smithyVersion = "1.41.1"

--- a/project/SmithyClasspath.scala
+++ b/project/SmithyClasspath.scala
@@ -7,17 +7,20 @@ import sbt.io.IO
 
 final case class SmithyClasspathEntry(
     module: sbt.ModuleID,
+    file: File
+)
+final case class SmithyClasspathDockerEntry(
+    module: sbt.ModuleID,
     file: File,
     relativePath: String
 )
 object SmithyClasspath {
-  def toFile(
+  def jsonConfig(
       target: File,
-      all: Seq[SmithyClasspathEntry],
-      dockerPath: String
+      all: Seq[(ModuleID, String)]
   ): Unit = {
-    val entries = all.map { sce =>
-      encodeModule(sce.module) -> ujson.Str(s"$dockerPath/${sce.relativePath}")
+    val entries = all.map { case (module, location) =>
+      encodeModule(module) -> ujson.Str(location)
     }.toMap
     val content = ujson.Obj(
       "entries" -> ujson.Obj.from(entries)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,5 @@ addSbtPlugin(
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.1")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
+addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -12,5 +12,14 @@ fi
 
 set -u
 
+# build frontend so it's available to be bundled
 (cd modules/frontend; npm i && npm run build)
-sbt "backend / Docker / $BACKEND_PUBLISH; backendDependencies / Docker / $BACKEND_PUBLISH"
+
+# build backend w/ default dependencies
+publish_backend="backend / Docker / $BACKEND_PUBLISH"
+sbt "$publish_backend"
+
+# build backend w/ additional dependencies
+tag_override="set backend / dockerTagOverride := Some(\"with-dependencies\")"
+smithy_classpath="set backend / smithyClasspath ++= Seq(\"com.disneystreaming.alloy\" % \"alloy-core\" % \"0.2.8\")"
+sbt "$tag_override; $smithy_classpath; $publish_backend"


### PR DESCRIPTION
Notable changes:

1. smithy4s-protocol is included in the default image
2. got rid of backendDependencies, instead, on CI we do two sbt publish with alternate settings to publish two different images
3. we configure `~reStart` so that it loads the dependencies correctly
4. added a label `smithy4s.version` to the docker images so we know what smithy4s version is in use in there