### PR TITLE
Bump smithy4s to 0.18.18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,11 +4,11 @@ import smithy4s_codegen._
 
 ThisBuild / organization := "com.example"
 ThisBuild / organizationName := "example"
-ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / scalaVersion := "2.13.14"
 ThisBuild / dynverSeparator := "-"
 
-val http4sVersion = "0.23.24"
-val smithyVersion = "1.41.1"
+val http4sVersion = "0.23.27"
+val smithyVersion = "1.45.0"
 val circeVersion = "0.14.1"
 val cirisVersion = "3.5.0"
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 addSbtPlugin(
-  "com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.18.3"
+  "com.disneystreaming.smithy4s" % "smithy4s-sbt-codegen" % "0.18.18"
 )
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.9.16")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.16.0")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -21,5 +21,5 @@ sbt "$publish_backend"
 
 # build backend w/ additional dependencies
 tag_override="set backend / dockerTagOverride := Some(\"with-dependencies\")"
-smithy_classpath="set backend / smithyClasspath ++= Seq(\"com.disneystreaming.alloy\" % \"alloy-core\" % \"0.2.8\")"
+smithy_classpath="set backend / smithyClasspath ++= Seq(\"com.disneystreaming.alloy\" % \"alloy-core\" % \"0.3.6\")"
 sbt "$tag_override; $smithy_classpath; $publish_backend"

--- a/smithy-build.json
+++ b/smithy-build.json
@@ -2,8 +2,8 @@
   "version": "1.0",
   "maven": {
     "dependencies": [
-      "com.disneystreaming.smithy4s:smithy4s-protocol:0.18.3",
-      "com.disneystreaming.alloy:alloy-core:0.2.8"
+      "com.disneystreaming.smithy4s:smithy4s-protocol:0.18.18",
+      "com.disneystreaming.alloy:alloy-core:0.3.6"
     ]
   },
   "imports": [


### PR DESCRIPTION
Tested by `sbt test`, also running `./scripts/build-image.sh` and manually testing the `with-dependencies` version for the result of https://github.com/disneystreaming/smithy4s/issues/1457. It looked OK
